### PR TITLE
use default nano db.follow() behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ var wrapper = function (methods, object) {
   });
 
   wrapped['follow'] = object['follow']
-
   return wrapped;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,8 @@ var wrapper = function (methods, object) {
     }
   });
 
+  wrapped['follow'] = object['follow']
+
   return wrapped;
 };
 
@@ -54,13 +56,11 @@ var promisify = function(nano) {
   , 'compact'
   , 'replicate'
   , 'changes'
-  , 'follow'
   ];
 
   var dbMethods = [
     'insert'
   , 'destroy'
-  , 'follow'
   , 'get'
   , 'head'
   , 'copy'


### PR DESCRIPTION
[nano.db.follow()](https://github.com/apache/couchdb-nano#nanodbfollowname-params-callback) returns the changes feed. Here's an example from the nano README

```
var feed = db.follow({since: "now"});
feed.on('change', function (change) {
  console.log("change: ", change);
});
feed.follow();
process.nextTick(function () {
  db.insert({"bar": "baz"}, "bar");
});
```


The example above does not work when using nano-promises.

Currently, the wrapped db.follow() returns a promise that resolves with a document change.  I think instead it should return the changes feed.  i.e use the regular nano.db.follow() instead of wrapping it.
